### PR TITLE
fix(quiz): 문제적 추러스 페이지 UI 개편

### DIFF
--- a/suspect-game/src/components/Navigation/LeftDrawer.tsx
+++ b/suspect-game/src/components/Navigation/LeftDrawer.tsx
@@ -46,7 +46,6 @@ const leftNavigationMenuItems: Record<
       text: "추러스 커넥션",
       url: "/connections",
       icon: <Dashboard />,
-      badgeText: "NEW",
     },
   ],
   "더 지니어스": [

--- a/suspect-game/src/features/quiz/components/QuizCard.tsx
+++ b/suspect-game/src/features/quiz/components/QuizCard.tsx
@@ -111,8 +111,8 @@ export default function QuizCard({
                 style={{
                   borderRadius: "0.5rem",
                 }}
-                width={isImageLoading ? 0 : 150}
-                height={isImageLoading ? 0 : 100}
+                width={isImageLoading ? 0 : 180}
+                height={isImageLoading ? 0 : 90}
                 priority
                 onLoadingComplete={() => setIsImageLoading(false)}
                 onError={() => setIsImageLoading(false)}
@@ -120,8 +120,8 @@ export default function QuizCard({
               {isImageLoading && (
                 <Skeleton
                   variant="rectangular"
-                  width="150px"
-                  height="100px"
+                  width="180px"
+                  height="90px"
                   sx={{
                     borderRadius: "0.5rem",
                     bgcolor: "rgba(255, 255, 255, 0.7)",

--- a/suspect-game/src/features/quiz/components/QuizCard.tsx
+++ b/suspect-game/src/features/quiz/components/QuizCard.tsx
@@ -1,130 +1,135 @@
 import {
   Box,
-  Button,
   Card,
-  CardActions,
+  CardActionArea,
   CardContent,
-  Divider,
   Grid,
-  Icon,
+  Skeleton,
   Typography,
 } from "@mui/material";
 import { QuizType } from "../types";
 import { useResponsiveValue } from "@/hooks/useResponsiveValue";
 import { useRouter } from "next/router";
 import Image from "next/image";
-import { CardStyle } from "../fixtures";
-import {
-  CheckCircleOutline,
-  Help,
-  RadioButtonUnchecked,
-  Star,
-} from "@mui/icons-material";
+import { CheckCircleOutline, RadioButtonUnchecked } from "@mui/icons-material";
 import { useState } from "react";
 
 export default function QuizCard({
   quiz,
-  month,
   isSolved,
+  bgColor,
 }: {
   quiz: QuizType;
-  month: string;
   isSolved: boolean;
+  bgColor?: string;
 }) {
   const responsiveXS = useResponsiveValue([6, 4, 2]);
   const [isImageLoading, setIsImageLoading] = useState(true);
   const router = useRouter();
 
-  const { baseColor, lightColor } = CardStyle[month] ?? {
-    baseColor: "rgba(255, 255, 255, 0.2)",
-    lightColor: "rgba(255, 255, 255, 0.3)",
-  };
+  const lightColor = "#ffe2db";
 
   return (
     <Grid item xs={responsiveXS}>
       <Card
         sx={{
-          background: lightColor,
+          backgroundColor: bgColor ?? lightColor,
+          minWidth: "150px",
           borderRadius: "0.75rem",
           boxShadow: "0 4px 30px rgba(255, 255, 255, 0.1)",
           border: "1px solid rgba(255, 255, 255, 0.3)",
           transition: "all 0.3s ease-in-out",
-          "&:hover": {
-            bgcolor: baseColor,
-          },
         }}
       >
-        <CardContent
+        <CardActionArea
           onClick={() => {
             router.push(`/quiz/${quiz.id}`);
           }}
-          sx={{
-            cursor: "pointer",
-            height: "100%",
-            display: "flex",
-            flexDirection: "column",
-            justifyContent: "center",
-          }}
         >
-          <Box
-            display="flex"
-            justifyContent="space-between"
-            alignItems="center"
-            mb={1}
+          <CardContent
+            sx={{
+              cursor: "pointer",
+              height: "100%",
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "center",
+            }}
           >
             <Box
-              color="#212837"
-              textAlign="left"
-              justifyContent="center"
               display="flex"
-              flexDirection="column"
-              whiteSpace="nowrap"
-              width="130px"
+              justifyContent="space-between"
+              alignItems="center"
+              mb={1}
             >
-              <Typography
-                fontSize={16}
-                fontFamily={"NanumSquareEB"}
-                fontWeight={700}
-                textOverflow="ellipsis"
+              <Box
+                color="#212837"
+                textAlign="left"
+                justifyContent="center"
+                display="flex"
+                flexDirection="column"
+                whiteSpace="nowrap"
                 overflow="hidden"
+                width="100%"
               >
-                {quiz.title}
-              </Typography>
+                <Typography
+                  fontSize={16}
+                  fontFamily={"NanumSquareEB"}
+                  fontWeight={700}
+                  textOverflow="ellipsis"
+                  overflow="hidden"
+                >
+                  {quiz.title}
+                </Typography>
+              </Box>
+              <Box display="flex" alignItems="center">
+                {isSolved ? (
+                  <CheckCircleOutline
+                    sx={{
+                      fontSize: "1.5rem",
+                    }}
+                  />
+                ) : (
+                  <RadioButtonUnchecked
+                    sx={{
+                      fontSize: "1.5rem",
+                    }}
+                  />
+                )}
+              </Box>
             </Box>
-            <Box display="flex" alignItems="center">
-              {isSolved ? (
-                <CheckCircleOutline
+            <Box
+              display="flex"
+              justifyContent="center"
+              alignItems="center"
+              width="100%"
+              height="100%"
+            >
+              <Image
+                src={quiz.quizImgSrc}
+                alt={quiz.title}
+                style={{
+                  borderRadius: "0.5rem",
+                }}
+                width={isImageLoading ? 0 : 150}
+                height={isImageLoading ? 0 : 100}
+                priority
+                onLoadingComplete={() => setIsImageLoading(false)}
+                onError={() => setIsImageLoading(false)}
+              />
+              {isImageLoading && (
+                <Skeleton
+                  variant="rectangular"
+                  width="150px"
+                  height="100px"
                   sx={{
-                    fontSize: "1.5rem",
-                  }}
-                />
-              ) : (
-                <RadioButtonUnchecked
-                  sx={{
-                    fontSize: "1.5rem",
+                    borderRadius: "0.5rem",
+                    bgcolor: "rgba(255, 255, 255, 0.7)",
                   }}
                 />
               )}
             </Box>
-          </Box>
-          <Box
-            display="flex"
-            justifyContent="center"
-            alignItems="center"
-            width="100%"
-            height="100%"
-          >
-            <Image
-              src={quiz.quizImgSrc}
-              alt={quiz.title}
-              width={isImageLoading ? 0 : 150}
-              height={isImageLoading ? 0 : 100}
-              priority
-              onLoadingComplete={() => setIsImageLoading(false)}
-              onError={() => setIsImageLoading(false)}
-            />
-          </Box>
-        </CardContent>
+          </CardContent>
+        </CardActionArea>
       </Card>
     </Grid>
   );

--- a/suspect-game/src/features/quiz/components/QuizCard.tsx
+++ b/suspect-game/src/features/quiz/components/QuizCard.tsx
@@ -85,6 +85,7 @@ export default function QuizCard({
                 {isSolved ? (
                   <CheckCircleOutline
                     sx={{
+                      color: "#20954f",
                       fontSize: "1.5rem",
                     }}
                   />

--- a/suspect-game/src/features/quiz/components/QuizCard.tsx
+++ b/suspect-game/src/features/quiz/components/QuizCard.tsx
@@ -6,6 +6,7 @@ import {
   CardContent,
   Divider,
   Grid,
+  Icon,
   Typography,
 } from "@mui/material";
 import { QuizType } from "../types";
@@ -13,7 +14,13 @@ import { useResponsiveValue } from "@/hooks/useResponsiveValue";
 import { useRouter } from "next/router";
 import Image from "next/image";
 import { CardStyle } from "../fixtures";
-import { Star } from "@mui/icons-material";
+import {
+  CheckCircleOutline,
+  Help,
+  RadioButtonUnchecked,
+  Star,
+} from "@mui/icons-material";
+import { useState } from "react";
 
 export default function QuizCard({
   quiz,
@@ -25,6 +32,7 @@ export default function QuizCard({
   isSolved: boolean;
 }) {
   const responsiveXS = useResponsiveValue([6, 4, 2]);
+  const [isImageLoading, setIsImageLoading] = useState(true);
   const router = useRouter();
 
   const { baseColor, lightColor } = CardStyle[month] ?? {
@@ -35,21 +43,14 @@ export default function QuizCard({
   return (
     <Grid item xs={responsiveXS}>
       <Card
-        variant="outlined"
         sx={{
-          minWidth: "150px",
-          maxWidth: "300px",
           background: lightColor,
-          borderRadius: "16px",
+          borderRadius: "0.75rem",
           boxShadow: "0 4px 30px rgba(255, 255, 255, 0.1)",
-          backdropFilter: "blur(10px)",
-          WebkitBackdropFilter: "blur(10px)",
           border: "1px solid rgba(255, 255, 255, 0.3)",
           transition: "all 0.3s ease-in-out",
           "&:hover": {
-            boxShadow: `0 10px 30px -10px ${baseColor}`,
-            border: `1px solid ${baseColor}`,
-            transform: "scale(1.1)",
+            bgcolor: baseColor,
           },
         }}
       >
@@ -59,52 +60,68 @@ export default function QuizCard({
           }}
           sx={{
             cursor: "pointer",
-            minHeight: "200px",
-            mb: 5,
+            height: "100%",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
           }}
         >
-          <Typography
-            sx={{ fontSize: 14 }}
-            color={baseColor}
-            gutterBottom
-            position="relative"
+          <Box
+            display="flex"
+            justifyContent="space-between"
+            alignItems="center"
+            mb={1}
           >
-            #{quiz.quizNumber}
-            {isSolved && (
-              <Star
-                sx={{
-                  verticalAlign: "middle",
-                  position: "absolute",
-                  right: 0,
-                  fontSize: "1rem",
-                }}
-              />
-            )}
-          </Typography>
-          <Typography
-            color="white"
-            variant="h5"
-            component="div"
-            sx={{
-              wordBreak: "keep-all",
-              minHeight: 100,
-              verticalAlign: "middle",
-            }}
-            fontWeight={700}
-            fontFamily={"NanumSquareEB"}
+            <Box
+              color="#212837"
+              textAlign="left"
+              justifyContent="center"
+              display="flex"
+              flexDirection="column"
+              whiteSpace="nowrap"
+              width="130px"
+            >
+              <Typography
+                fontSize={16}
+                fontFamily={"NanumSquareEB"}
+                fontWeight={700}
+                textOverflow="ellipsis"
+                overflow="hidden"
+              >
+                {quiz.title}
+              </Typography>
+            </Box>
+            <Box display="flex" alignItems="center">
+              {isSolved ? (
+                <CheckCircleOutline
+                  sx={{
+                    fontSize: "1.5rem",
+                  }}
+                />
+              ) : (
+                <RadioButtonUnchecked
+                  sx={{
+                    fontSize: "1.5rem",
+                  }}
+                />
+              )}
+            </Box>
+          </Box>
+          <Box
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            width="100%"
+            height="100%"
           >
-            {quiz.title}
-            <Typography sx={{ mb: 1.5 }} color="lightgray">
-              {quiz.madeBy && `by ${quiz.madeBy}`}
-            </Typography>
-          </Typography>
-
-          <Box display="flex" justifyContent="center">
             <Image
-              alt="quiz icon"
-              src="/image/quiz/icon/default.png"
-              width={100}
-              height={120}
+              src={quiz.quizImgSrc}
+              alt={quiz.title}
+              width={isImageLoading ? 0 : 150}
+              height={isImageLoading ? 0 : 100}
+              priority
+              onLoadingComplete={() => setIsImageLoading(false)}
+              onError={() => setIsImageLoading(false)}
             />
           </Box>
         </CardContent>

--- a/suspect-game/src/features/quiz/fixtures/index.ts
+++ b/suspect-game/src/features/quiz/fixtures/index.ts
@@ -16,60 +16,57 @@ export const MEETINGS = [
   "2019년 9월 정기모임",
 ] as const;
 
-export const CardStyle: Record<
+export const MeetingData: Record<
   string,
   {
-    baseColor: string;
-    lightColor: string;
+    title?: string;
+    color: string;
   }
 > = {
-  "1월": {
-    baseColor: "rgba(241, 27, 33, 0.7)",
-    lightColor: "rgba(241, 27, 33, 0.3)",
+  "2019년 9월 정기모임": {
+    color: "#ffe2db",
   },
-  "2월": {
-    baseColor: "rgba(252, 152, 249, 0.7)",
-    lightColor: "rgba(252, 152, 249, 0.3)",
+  "2019년 11월 정기모임": {
+    color: "#cef0ff",
   },
-  "3월": {
-    baseColor: "rgba(156, 224, 254, 0.7)",
-    lightColor: "rgba(156, 224, 254, 0.3)",
+  "2022년 6월 정기모임": {
+    color: "#d7f4dd",
   },
-  "4월": {
-    baseColor: "rgba(255, 255, 255, 0.7)",
-    lightColor: "rgba(255, 255, 255, 0.3)",
+  "2022년 7월 정기모임": {
+    color: "#fde2e2",
   },
-  "5월": {
-    baseColor: "rgba(20, 248, 165, 0.7)",
-    lightColor: "rgba(20, 248, 165, 0.3)",
+  "2022년 9월 정기모임": {
+    color: "#e2e2ff",
   },
-  "6월": {
-    baseColor: "rgba(166, 92, 215)",
-    lightColor: "rgba(166, 92, 215, 0.3)",
+  "2022년 11월 정기모임": {
+    color: "#bbd0fc",
+    title: "달나라 너머",
   },
-  "7월": {
-    baseColor: "rgba(253, 70, 126)",
-    lightColor: "rgba(253, 70, 126, 0.3)",
+  "2022년 12월 정기모임": {
+    color: "#fff3d4",
   },
-  "8월": {
-    baseColor: "rgba(191, 253, 40, 0.7)",
-    lightColor: "rgba(191, 253, 40, 0.3)",
+  "2023년 1월 1차 정기모임": {
+    color: "#f4beab",
+    title: "토끼와 거북이",
   },
-  "9월": {
-    baseColor: "rgba(48, 174, 251)",
-    lightColor: "rgba(48, 174, 251, 0.3)",
+  "2023년 3월 정기모임": {
+    color: "#fde2e2",
+    title: "2023 추러스 OT",
   },
-  "10월": {
-    baseColor: "rgba(44, 162, 175)",
-    lightColor: "rgba(44, 162, 175, 0.3)",
+  "2023년 4월 정기모임": {
+    color: "#c3e0f4",
+    title: "게임 속 여행",
   },
-  "11월": {
-    baseColor: "rgba(241, 97, 10)",
-    lightColor: "rgba(241, 97, 10, 0.3)",
+  "2023년 6월 정기모임": {
+    color: "#b1b1b1",
   },
-  "12월": {
-    baseColor: "rgba(72, 228, 229)",
-    lightColor: "rgba(72, 228, 229, 0.3)",
+  "2023년 9월 정기모임": {
+    color: "#fde2e2",
+    title: "Welcome to CHURRUS",
+  },
+  "2023년 11월 정기모임": {
+    color: "#d3f6f6",
+    title: "일찍 온 크리스마스",
   },
 };
 

--- a/suspect-game/src/features/quiz/fixtures/index.ts
+++ b/suspect-game/src/features/quiz/fixtures/index.ts
@@ -1,77 +1,91 @@
 import { QuizType } from "../types";
 
 export const MEETINGS = [
-  "2023년 11월 정기모임",
-  "2023년 9월 정기모임",
-  "2023년 6월 정기모임",
-  "2023년 4월 정기모임",
-  "2023년 3월 정기모임",
-  "2023년 1월 1차 정기모임",
-  "2022년 12월 정기모임",
-  "2022년 11월 정기모임",
-  "2022년 9월 정기모임",
-  "2022년 7월 정기모임",
-  "2022년 6월 정기모임",
-  "2019년 11월 정기모임",
-  "2019년 9월 정기모임",
+  "2023-11",
+  "2023-9",
+  "2023-6",
+  "2023-4",
+  "2023-3",
+  "2023-1-1",
+  "2022-12",
+  "2022-11",
+  "2022-9",
+  "2022-7",
+  "2022-6",
+  "2019-11",
+  "2019-9",
 ] as const;
 
 export const MeetingData: Record<
   string,
   {
-    title?: string;
+    title: string;
+    subtitle?: string;
     color: string;
   }
 > = {
-  "2019년 9월 정기모임": {
+  "2019-9": {
+    title: "2019년 9월 정기모임",
     color: "#ffe2db",
   },
-  "2019년 11월 정기모임": {
+  "2019-11": {
+    title: "2019년 11월 정기모임",
     color: "#cef0ff",
   },
-  "2022년 6월 정기모임": {
+  "2022-6": {
+    title: "2022년 6월 정기모임",
     color: "#d7f4dd",
   },
-  "2022년 7월 정기모임": {
+  "2022-7": {
+    title: "2022년 7월 정기모임",
     color: "#fde2e2",
   },
-  "2022년 9월 정기모임": {
+  "2022-9": {
+    title: "2022년 9월 정기모임",
     color: "#e2e2ff",
   },
-  "2022년 11월 정기모임": {
+  "2022-11": {
+    title: "2022년 11월 정기모임",
     color: "#bbd0fc",
-    title: "달나라 너머",
+    subtitle: "달나라 너머",
   },
-  "2022년 12월 정기모임": {
+  "2022-12": {
+    title: "2022년 12월 정기모임",
     color: "#fff3d4",
   },
-  "2023년 1월 1차 정기모임": {
+  "2023-1-1": {
+    title: "2023년 1월 1차 정기모임",
     color: "#f4beab",
-    title: "토끼와 거북이",
+    subtitle: "토끼와 거북이",
   },
-  "2023년 3월 정기모임": {
+  "2023-3": {
+    title: "2023년 3월 정기모임",
     color: "#fde2e2",
-    title: "2023 추러스 OT",
+    subtitle: "2023 추러스 OT",
   },
-  "2023년 4월 정기모임": {
+  "2023-4": {
+    title: "2023년 4월 정기모임",
     color: "#c3e0f4",
-    title: "게임 속 여행",
+    subtitle: "게임 속 여행",
   },
-  "2023년 6월 정기모임": {
+  "2023-6": {
+    title: "2023년 6월 정기모임",
     color: "#b1b1b1",
   },
-  "2023년 9월 정기모임": {
+  "2023-9": {
+    title: "2023년 9월 정기모임",
     color: "#fde2e2",
-    title: "Welcome to CHURRUS",
+    subtitle: "Welcome to CHURRUS",
   },
-  "2023년 11월 정기모임": {
+  "2023-11": {
+    title: "2023년 11월 정기모임",
     color: "#d3f6f6",
-    title: "일찍 온 크리스마스",
+    subtitle: "일찍 온 크리스마스",
   },
 };
 
 export const QuizData: Record<string, QuizType[]> = {
-  "2019년 9월 정기모임": [
+  "2019-9": [
     {
       id: "2019-9-1",
       quizNumber: 1,
@@ -153,7 +167,7 @@ export const QuizData: Record<string, QuizType[]> = {
       isAnswerable: true,
     },
   ],
-  "2019년 11월 정기모임": [
+  "2019-11": [
     {
       id: "2019-11-1",
       quizNumber: 1,
@@ -236,7 +250,7 @@ export const QuizData: Record<string, QuizType[]> = {
       isAnswerable: false,
     },
   ],
-  "2022년 6월 정기모임": [
+  "2022-6": [
     {
       id: "2022-6-1",
       quizNumber: 1,
@@ -278,7 +292,7 @@ export const QuizData: Record<string, QuizType[]> = {
       isAnswerable: false,
     },
   ],
-  "2022년 7월 정기모임": [
+  "2022-7": [
     {
       id: "2022-7-1",
       quizNumber: 1,
@@ -370,7 +384,7 @@ export const QuizData: Record<string, QuizType[]> = {
       isAnswerable: true,
     },
   ],
-  "2022년 9월 정기모임": [
+  "2022-9": [
     {
       id: "2022-9-1",
       quizNumber: 1,
@@ -422,7 +436,7 @@ export const QuizData: Record<string, QuizType[]> = {
       isAnswerable: true,
     },
   ],
-  "2022년 11월 정기모임": [
+  "2022-11": [
     {
       id: "2022-11-1",
       quizNumber: 1,
@@ -504,7 +518,7 @@ export const QuizData: Record<string, QuizType[]> = {
       isAnswerable: false,
     },
   ],
-  "2022년 12월 정기모임": [
+  "2022-12": [
     {
       id: "2022-12-1",
       quizNumber: 1,
@@ -536,7 +550,7 @@ export const QuizData: Record<string, QuizType[]> = {
       isAnswerable: true,
     },
   ],
-  "2023년 1월 1차 정기모임": [
+  "2023-1-1": [
     {
       id: "2023-1-1",
       quizNumber: 1,
@@ -629,7 +643,7 @@ export const QuizData: Record<string, QuizType[]> = {
     },
   ],
 
-  "2023년 3월 정기모임": [
+  "2023-3": [
     {
       id: "2023-3-1",
       quizNumber: 1,
@@ -711,7 +725,7 @@ export const QuizData: Record<string, QuizType[]> = {
       isAnswerable: true,
     },
   ],
-  "2023년 4월 정기모임": [
+  "2023-4": [
     {
       id: "2023-4-1",
       quizNumber: 1,
@@ -793,7 +807,7 @@ export const QuizData: Record<string, QuizType[]> = {
       isAnswerable: false,
     },
   ],
-  "2023년 6월 정기모임": [
+  "2023-6": [
     {
       id: "2023-6-1",
       quizNumber: 1,
@@ -835,7 +849,7 @@ export const QuizData: Record<string, QuizType[]> = {
       isAnswerable: true,
     },
   ],
-  "2023년 9월 정기모임": [
+  "2023-9": [
     {
       id: "2023-9-1",
       quizNumber: 1,
@@ -907,7 +921,7 @@ export const QuizData: Record<string, QuizType[]> = {
       isAnswerable: true,
     },
   ],
-  "2023년 11월 정기모임": [
+  "2023-11": [
     {
       id: "2023-11-1",
       quizNumber: 1,

--- a/suspect-game/src/pages/index.tsx
+++ b/suspect-game/src/pages/index.tsx
@@ -64,7 +64,7 @@ const CONTENTS: ContentType[] = [
         }}
       />
     ),
-    label: "NEW",
+    label: "Weekly",
     url: "connections",
     color: {
       main: "#d7f4dd",

--- a/suspect-game/src/pages/index.tsx
+++ b/suspect-game/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import { useResponsiveValue } from "@/hooks/useResponsiveValue";
-import { Box, Button, Grid, Typography } from "@mui/material";
+import { Box, Grid, Typography } from "@mui/material";
 import {
   CategoryOutlined,
   Dashboard,
@@ -7,19 +7,17 @@ import {
   HelpOutlineOutlined,
   IndeterminateCheckBoxOutlined,
   LaunchOutlined,
-  PlayArrowSharp,
   Quiz,
   Search,
 } from "@mui/icons-material";
 import GlobalHeader from "@/components/Navigation/GlobalHeader";
 import ContentCard, { ContentType } from "@/components/ContentCard";
 import GeniusCard, { GeniusContentType } from "@/components/GeniusCard";
-import { useRouter } from "next/router";
+
 import ExternalGameCard, {
   ExternalGameContentType,
 } from "@/components/ExternalGameCard";
 import MainBanner from "@/components/MainBanner";
-import LeftDrawer from "@/components/Navigation/LeftDrawer";
 
 const CONTENTS: ContentType[] = [
   {

--- a/suspect-game/src/pages/quiz/[...id].tsx
+++ b/suspect-game/src/pages/quiz/[...id].tsx
@@ -3,6 +3,7 @@ import {
   Alert,
   Box,
   Button,
+  FormControl,
   IconButton,
   Skeleton,
   TextField,
@@ -12,6 +13,9 @@ import { useRouter } from "next/router";
 import Image from "next/image";
 import { ArrowBack } from "@mui/icons-material";
 import { useState } from "react";
+import Head from "next/head";
+
+const BACKGROUND_COLOR = "#fffef8";
 
 const uppercaseRegex = /^[A-Z\s]+$/;
 const lowercaseRegex = /^[a-z\s]+$/;
@@ -37,7 +41,8 @@ export default function QuizPage() {
   const isAnswerPage = id[1] === "answer";
 
   if (!quiz) {
-    return <div>loading...</div>;
+    router.back();
+    return;
   }
 
   const [year, month, _] = quiz.id.split("-");
@@ -48,7 +53,8 @@ export default function QuizPage() {
     return;
   };
 
-  const handleAnswerSubmit = () => {
+  const handleAnswerSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
     if (inputAnswer === quiz.answer) {
       window.alert("정답입니다!");
       handleSolvedQuiz();
@@ -79,6 +85,9 @@ export default function QuizPage() {
 
   return (
     <>
+      <Head>
+        <title>문제적 추러스 : {quiz.title}</title>
+      </Head>
       <Box
         height="100vh"
         alignItems="center"
@@ -87,11 +96,7 @@ export default function QuizPage() {
         py={5}
         px={7}
         textAlign="center"
-        sx={{
-          background: `linear-gradient(50deg, rgba(0,0,0,1) 0%, rgba(31,31,31,1) 36%, rgba(21,21,21,1) 38%, rgba(0,0,0,1) 100%)`,
-          backgroundImage: `url("https://i.pinimg.com/564x/d3/b9/24/d3b9245271777a8004a26f529fed7cfc.jpg")`,
-          backgroundSize: "cover",
-        }}
+        bgcolor={BACKGROUND_COLOR}
       >
         <IconButton
           size="large"
@@ -100,47 +105,35 @@ export default function QuizPage() {
             top: 20,
             left: 20,
             zIndex: 100,
-            color: "white",
+            color: "#212837",
           }}
           onClick={() => {
-            router.push("/quiz", undefined, { scroll: false });
+            router.back();
           }}
         >
           <ArrowBack />
         </IconButton>
         <Typography
           variant="body1"
-          color="lightgray"
+          color="#606b80"
           fontWeight={600}
           sx={{
             mb: 1,
-            textShadow:
-              "2px 7px 5px rgba(255,255,255,0.3), 0px -4px 10px rgba(0,0,0,0.3)",
           }}
         >
           {year}년 {month}월 정기모임 #{quiz.quizNumber}
         </Typography>
 
-        <Typography
-          variant="h4"
-          color="white"
-          fontWeight={600}
-          sx={{
-            textShadow:
-              "2px 7px 5px rgba(255,255,255,0.3), 0px -4px 10px rgba(0,0,0,0.3)",
-          }}
-        >
+        <Typography variant="h4" color="#212837" fontWeight={600}>
           {quiz.title}
           {isAnswerPage && (quiz.answer ? ` 정답 : ${quiz.answer}` : ` 정답`)}
         </Typography>
         <Typography
           variant="body2"
-          color="gray"
+          color="#606b80"
           fontWeight={600}
           sx={{
             mb: 1,
-            textShadow:
-              "2px 7px 5px rgba(255,255,255,0.3), 0px -4px 10px rgba(0,0,0,0.3)",
           }}
         >
           {quiz.madeBy && `by ${quiz.madeBy}`}
@@ -188,15 +181,13 @@ export default function QuizPage() {
           />
         )}
         {!isAnswerPage && (
-          <>
+          <form onSubmit={handleAnswerSubmit}>
             <Typography
               variant="body1"
-              color="white"
+              color="#212837"
               fontWeight={400}
               sx={{
                 mt: 2,
-                textShadow:
-                  "2px 7px 5px rgba(255,255,255,0.3), 0px -4px 10px rgba(0,0,0,0.3)",
               }}
             >
               정답 형식: {answerFomat()}
@@ -205,20 +196,15 @@ export default function QuizPage() {
               <Box mt="20px" display="flex" alignContent="center">
                 <TextField
                   variant="outlined"
-                  disabled={!quiz.isAnswerable}
                   value={inputAnswer}
                   onChange={(e) => {
                     setInputAnswer(e.target.value);
                   }}
                   sx={{
-                    border: "gray 1px solid",
                     width: "40vw",
                     mr: 2,
+                    borderRadius: "24px",
                     minWidth: "200px",
-                    backgroundColor: "rgba(255, 255, 255, 0.7)",
-                    borderRadius: "16px",
-                    backdropFilter: "blur(10px)",
-                    WebkitBackdropFilter: "blur(10px)",
                   }}
                   placeholder={
                     quiz.isAnswerable
@@ -229,12 +215,13 @@ export default function QuizPage() {
                 <Button
                   sx={{
                     color: "white",
-
-                    borderRadius: "16px",
-                    backdropFilter: "blur(10px)",
+                    bgcolor: "#fa6556",
+                    borderRadius: "8px",
+                    "&:hover": {
+                      bgcolor: "#ffc7c6",
+                    },
                   }}
-                  onClick={handleAnswerSubmit}
-                  variant="outlined"
+                  type="submit"
                 >
                   제출
                 </Button>
@@ -242,8 +229,14 @@ export default function QuizPage() {
             )}
             <Button
               variant="outlined"
-              color="error"
               sx={{
+                border: "1px solid #eeb801",
+                color: "#eeb801",
+                "&:hover": {
+                  bgcolor: "#fff3d4",
+                  borderColor: "#eeb801",
+                  color: "#eeb801",
+                },
                 mt: "10px",
               }}
               size="small"
@@ -254,7 +247,7 @@ export default function QuizPage() {
             >
               정답 확인
             </Button>
-          </>
+          </form>
         )}
       </Box>
     </>

--- a/suspect-game/src/pages/quiz/index.tsx
+++ b/suspect-game/src/pages/quiz/index.tsx
@@ -1,3 +1,4 @@
+import GlobalHeader from "@/components/Navigation/GlobalHeader";
 import QuizCard from "@/features/quiz/components/QuizCard";
 import { MEETINGS, QuizData } from "@/features/quiz/fixtures";
 import { useResponsiveValue } from "@/hooks/useResponsiveValue";
@@ -6,8 +7,9 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
+const BACKGROUND_COLOR = "#fffef8";
+
 export default function Quiz() {
-  const responsivePX = useResponsiveValue([24, 60, 220]);
   const [solvedQuiz, setSolvedQuiz] = useState<string[]>([]);
 
   const router = useRouter();
@@ -22,54 +24,15 @@ export default function Quiz() {
       <Head>
         <title>문제적 추러스 : 서울대 추리 동아리</title>
       </Head>
+      <GlobalHeader />
       <Box
-        height="100vh"
-        sx={{
-          backgroundImage:
-            'linear-gradient(rgba(0,0,0,0.2), rgba(0,0,0,0.2)), url("https://i.pinimg.com/564x/d3/b9/24/d3b9245271777a8004a26f529fed7cfc.jpg")',
-          backgroundSize: "cover",
-          backgroundPosition: "center",
-        }}
+        height="100dvh"
+        bgcolor={BACKGROUND_COLOR}
+        display="flex"
+        justifyContent="center"
       >
-        <Box
-          color="white"
-          display="flex"
-          justifyContent="flex-start"
-          alignItems={"center"}
-          position="fixed"
-          top={0}
-          left={0}
-          width="100%"
-          px="24px"
-          height="60px"
-          zIndex={100}
-          bgcolor={"rgba(0, 0, 0, 0)"}
-          sx={{
-            backdropFilter: "blur(60px)",
-          }}
-        >
-          <Typography
-            variant="h5"
-            fontWeight={500}
-            onClick={() => {
-              router.push("/");
-            }}
-            sx={{
-              cursor: "pointer",
-            }}
-          >
-            CHURRUS
-          </Typography>
-        </Box>
-
-        <Box
-          height="100vh"
-          overflow="scroll"
-          px={`
-      ${responsivePX}px
-      `}
-        >
-          <Box width="100%" textAlign="center" color="white" mt="80px">
+        <Box height="100vh" overflow="scroll" maxWidth={1200} px={4}>
+          <Box width="100%" textAlign="center" color="#212837" mt="100px">
             <Typography
               variant="h3"
               fontWeight={600}
@@ -85,19 +48,6 @@ export default function Quiz() {
               }}
             >
               역대 정기모임에 있었던 문제들을 풀어볼 수 있어요.
-            </Typography>
-            <Typography
-              variant="h6"
-              sx={{
-                wordBreak: "keep-all",
-              }}
-            >
-              추러스에서 진행된{" "}
-              {Object.values(QuizData).reduce(
-                (acc, cur) => acc + cur.length,
-                0
-              )}
-              개의 문제 중, 현재 {solvedQuiz.length}개의 문제를 풀었어요!
             </Typography>
           </Box>
 

--- a/suspect-game/src/pages/quiz/index.tsx
+++ b/suspect-game/src/pages/quiz/index.tsx
@@ -1,18 +1,26 @@
 import GlobalHeader from "@/components/Navigation/GlobalHeader";
 import QuizCard from "@/features/quiz/components/QuizCard";
-import { MEETINGS, QuizData } from "@/features/quiz/fixtures";
-import { useResponsiveValue } from "@/hooks/useResponsiveValue";
-import { Box, Divider, Grid, Typography } from "@mui/material";
+import { MEETINGS, MeetingData, QuizData } from "@/features/quiz/fixtures";
+import {
+  ArrowBackIos,
+  ArrowForwardIos,
+  ArrowLeft,
+  ArrowRight,
+} from "@mui/icons-material";
+import { Box, Divider, Grid, IconButton, Typography } from "@mui/material";
 import Head from "next/head";
-import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
 const BACKGROUND_COLOR = "#fffef8";
 
+type MeetingType = (typeof MEETINGS)[number];
+
 export default function Quiz() {
   const [solvedQuiz, setSolvedQuiz] = useState<string[]>([]);
 
-  const router = useRouter();
+  const [selectedMeeting, setSelectedMeeting] = useState<MeetingType>(
+    MEETINGS[0]
+  );
 
   useEffect(() => {
     const solvedQuizzes = JSON.parse(localStorage.getItem("quiz") ?? "[]");
@@ -31,8 +39,21 @@ export default function Quiz() {
         display="flex"
         justifyContent="center"
       >
-        <Box height="100vh" overflow="scroll" maxWidth={1200} px={4}>
-          <Box width="100%" textAlign="center" color="#212837" mt="100px">
+        <Box
+          height="100vh"
+          overflow="scroll"
+          px={[3, 4, 12]}
+          width="100%"
+          pb={6}
+          bgcolor={BACKGROUND_COLOR}
+        >
+          <Box
+            width="100%"
+            textAlign="center"
+            color="#212837"
+            mt="100px"
+            mb={[3, 4, 6]}
+          >
             <Typography
               variant="h3"
               fontWeight={600}
@@ -41,7 +62,7 @@ export default function Quiz() {
               문제적 추러스
             </Typography>
             <Typography
-              variant="h6"
+              variant="body1"
               fontFamily={"NanumSquareEB"}
               sx={{
                 wordBreak: "keep-all",
@@ -51,35 +72,78 @@ export default function Quiz() {
             </Typography>
           </Box>
 
-          {MEETINGS.map((meeting) => (
-            <Box mb="100px">
-              <Divider
-                textAlign="left"
-                light
+          <Box
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            mb={3}
+          >
+            <IconButton
+              disabled={
+                MEETINGS.indexOf(selectedMeeting) === MEETINGS.length - 1
+              }
+              onClick={() => {
+                const index = MEETINGS.indexOf(selectedMeeting);
+                if (index === MEETINGS.length - 1) return;
+                setSelectedMeeting(MEETINGS[index + 1]);
+              }}
+            >
+              <ArrowBackIos />
+            </IconButton>
+            <Box
+              minHeight="58px"
+              minWidth="250px"
+              justifyContent="center"
+              alignItems="center"
+              lineHeight="58px"
+              display="flex"
+              flexDirection="column"
+            >
+              <Typography
+                variant="h5"
+                fontWeight={600}
+                fontFamily="NanumSquareEB"
                 sx={{
-                  color: "white",
-                  mb: 3,
-                  mt: 10,
-                  fontSize: "1.2rem",
-                  "&::before, &::after": {
-                    borderColor: "white",
-                  },
+                  wordBreak: "keep-all",
                 }}
               >
-                {meeting}
-              </Divider>
-              <Grid container spacing={3}>
-                {QuizData[meeting].map((quiz) => (
-                  <QuizCard
-                    isSolved={solvedQuiz.includes(quiz.id)}
-                    key={quiz.id}
-                    quiz={quiz}
-                    month={meeting.split(" ")[1]}
-                  />
-                ))}
-              </Grid>
+                {selectedMeeting}
+              </Typography>
+              {MeetingData[selectedMeeting].title && (
+                <Typography
+                  textAlign="center"
+                  variant="body1"
+                  fontFamily={"NanumSquareEB"}
+                  sx={{
+                    wordBreak: "keep-all",
+                  }}
+                >
+                  {MeetingData[selectedMeeting].title}
+                </Typography>
+              )}
             </Box>
-          ))}
+            <IconButton
+              disabled={MEETINGS.indexOf(selectedMeeting) === 0}
+              onClick={() => {
+                const index = MEETINGS.indexOf(selectedMeeting);
+                if (index === 0) return;
+                setSelectedMeeting(MEETINGS[index - 1]);
+              }}
+            >
+              <ArrowForwardIos />
+            </IconButton>
+          </Box>
+
+          <Grid container spacing={3} width="100%">
+            {QuizData[selectedMeeting].map((quiz) => (
+              <QuizCard
+                key={quiz.id}
+                quiz={quiz}
+                isSolved={solvedQuiz.includes(quiz.id)}
+                bgColor={MeetingData[selectedMeeting]?.color ?? "#fffef8"}
+              />
+            ))}
+          </Grid>
         </Box>
       </Box>
     </>

--- a/suspect-game/src/pages/quiz/index.tsx
+++ b/suspect-game/src/pages/quiz/index.tsx
@@ -1,15 +1,12 @@
 import GlobalHeader from "@/components/Navigation/GlobalHeader";
 import QuizCard from "@/features/quiz/components/QuizCard";
 import { MEETINGS, MeetingData, QuizData } from "@/features/quiz/fixtures";
-import {
-  ArrowBackIos,
-  ArrowForwardIos,
-  ArrowLeft,
-  ArrowRight,
-} from "@mui/icons-material";
-import { Box, Divider, Grid, IconButton, Typography } from "@mui/material";
+import { ArrowBackIos, ArrowForwardIos } from "@mui/icons-material";
+import { Box, Grid, IconButton, Typography } from "@mui/material";
 import Head from "next/head";
 import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { useRouter } from "next/router";
 
 const BACKGROUND_COLOR = "#fffef8";
 
@@ -18,14 +15,22 @@ type MeetingType = (typeof MEETINGS)[number];
 export default function Quiz() {
   const [solvedQuiz, setSolvedQuiz] = useState<string[]>([]);
 
-  const [selectedMeeting, setSelectedMeeting] = useState<MeetingType>(
-    MEETINGS[0]
-  );
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const selectedMeeting =
+    (searchParams.get("meeting") as MeetingType) ?? MEETINGS[0];
 
   useEffect(() => {
     const solvedQuizzes = JSON.parse(localStorage.getItem("quiz") ?? "[]");
     setSolvedQuiz(solvedQuizzes);
   }, []);
+
+  useEffect(() => {
+    if (!MeetingData[selectedMeeting]) {
+      router.push(`/quiz?meeting=${MEETINGS[0]}`);
+    }
+  }, [selectedMeeting]);
 
   return (
     <>
@@ -85,7 +90,7 @@ export default function Quiz() {
               onClick={() => {
                 const index = MEETINGS.indexOf(selectedMeeting);
                 if (index === MEETINGS.length - 1) return;
-                setSelectedMeeting(MEETINGS[index + 1]);
+                router.push(`/quiz?meeting=${MEETINGS[index + 1]}`);
               }}
             >
               <ArrowBackIos />
@@ -107,9 +112,9 @@ export default function Quiz() {
                   wordBreak: "keep-all",
                 }}
               >
-                {selectedMeeting}
+                {MeetingData[selectedMeeting]?.title}
               </Typography>
-              {MeetingData[selectedMeeting].title && (
+              {MeetingData[selectedMeeting]?.subtitle && (
                 <Typography
                   textAlign="center"
                   variant="body1"
@@ -118,7 +123,7 @@ export default function Quiz() {
                     wordBreak: "keep-all",
                   }}
                 >
-                  {MeetingData[selectedMeeting].title}
+                  {MeetingData[selectedMeeting].subtitle}
                 </Typography>
               )}
             </Box>
@@ -127,7 +132,7 @@ export default function Quiz() {
               onClick={() => {
                 const index = MEETINGS.indexOf(selectedMeeting);
                 if (index === 0) return;
-                setSelectedMeeting(MEETINGS[index - 1]);
+                router.push(`/quiz?meeting=${MEETINGS[index - 1]}`);
               }}
             >
               <ArrowForwardIos />
@@ -135,7 +140,7 @@ export default function Quiz() {
           </Box>
 
           <Grid container spacing={3} width="100%">
-            {QuizData[selectedMeeting].map((quiz) => (
+            {QuizData[selectedMeeting]?.map((quiz) => (
               <QuizCard
                 key={quiz.id}
                 quiz={quiz}


### PR DESCRIPTION
As-is
<img width="647" alt="image" src="https://github.com/mgahn0706/suspect-web/assets/13569506/af056c17-b840-404b-8cd0-7114f1315b93">

To-be
<img width="649" alt="image" src="https://github.com/mgahn0706/suspect-web/assets/13569506/ae50a9fb-54d8-44d6-bb0b-f2cedd3b0055">

문제적 추러스 아카이브 페이지의 UI/UX를 개선합니다.

- 메인 페이지 개편에 따라 디자인 톤앤매너를 맞춰줄 필요가 있었습니다.
- 정기모임 횟수가 많아질수록 스크롤이 무한정 길어져, 이전 정기모임까지 스크롤해야하는 길이가 계속 늘어날 우려가 있었습니다. 페이지네이션 형식을 변경합니다.
- 정기모임 리스트에서 문제의 모양새를 미리 볼 수 있도록 합니다. 사용자로 하여금 이것이 어떤 문제인지 바로 파악할 수 있도록합니다.
- 문제 아이콘보다는 실제 이미지를 사용하여 시각적 자극을 증가시키고, 해당 문제 카드의 가시성을 높입니다.
- urlSearchParam을 사용하여 사용자가 back 버튼을 눌렀을때, 이전의 정기모임 페이지로 바로 이동할 수 있도록 하여 UX를 개선합니다.
- 정답 제출 페이지에 form을 감싸서, 마우스 엔터 등으로 간편하여 form을 제출할 수 있도록 합니다.
- 아직 안푼문제에도 원을 표시하여, 만약 풀었을 경우 해당 원에 체크표시가 되도록 합니다. 사용자로 하여금 해당 UI의 목적을 더 잘 알 수 있게 합니다. 기존에는 '별'이 무슨 의미인지 모르는 사용자가 많았습니다.